### PR TITLE
Rewrote buildscript for broader OS support, github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build Font
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # installs python3
+      - uses: actions/setup-python@v2.2.2
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ backups/*
 logs/*
 *.otf
 
+src/pysilfont

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ An example of text can be seen here:
 ### Prerequisites
 
 * have python3 and imagemagick installed (commands vary per OS)
-* Install python scripts:
-    * `pip3 install fontmake`
-    * `pip3 install git+https://github.com/silnrsi/pysilfont`
-    * `python3 -m pip install fonttools[ufo,lxml,woff,unicode]`
 
 ### Run builder
 

--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,57 @@
 #!/usr/bin/env bash
 
+# Detect ImageMagick - newer versions use the command "magick" instead of "convert"
+IMAGEMAGICK="$(which magick 2>/dev/null)"
+if [[ -z "$IMAGEMAGICK" ]]; then
+  IMAGEMAGICK="$(which convert 2>/dev/null)"
+fi
+
+# ImageMagick is not needed for primary font generation
+if ! "$IMAGEMAGICK" wizard: /dev/null 2>/dev/null; then
+  echo "No ImageMagick available; skipping demo image generation"
+  IMAGEMAGICK=""
+fi
+
+# Detect Python; prefer python 3.x
+PYTHON="$(which python3 2>/dev/null)"
+if [[ -z "$PYTHON" ]]; then
+  PYTHON="$(which python 2>/dev/null)"
+fi
+
+if [[ -z "$PYTHON" ]]; then
+  echo "No Python installed.  Aborting." >&2
+  exit -1
+fi
+
+PSFNORMALIZE="$(which psfnormalize 2>/dev/null)"
+
+# If psfnormalize isn't present, try to install it, and the other req's
+if [[ -z "$PSFNORMALIZE" ]]; then
+  rm -rf ~/work/mawkin-sans/mawkin-sans/src/pysilfont > /dev/null 2>&1
+  "$PYTHON" -m pip install -r requirements.txt
+fi
+
 set -e
 
 psfnormalize mawkin_sans.ufo
 
-fontmake --validate-ufo --autohint --ufo-paths mawkin_sans.ufo --output otf --output-path mawkin_sans.otf
+"$PYTHON" -m fontmake --validate-ufo --autohint --ufo-paths mawkin_sans.ufo --output otf --output-path mawkin_sans.otf
 
-convert -background white -fill black \
-          -font './mawkin_sans.otf' -pointsize 200 label:"Mawkin\n. .Sans" \
-          title.png
+if [[ -n "$IMAGEMAGICK" ]]; then
+  echo "Generating title.png"
+  "$IMAGEMAGICK" -background white -fill black \
+            -font './mawkin_sans.otf' -pointsize 200 label:"Mawkin\n. .Sans" \
+            title.png
 
-convert -background white -fill black \
-          -font './mawkin_sans.otf' -pointsize 60 label:"the last metroid\n. .is in captivity\nthe galaxy\n. .is at peace\n\n\nMawkin\n. .Sans" \
-          demo.png
+  echo "Generating demo.png"
+  "$IMAGEMAGICK" -background white -fill black \
+            -font './mawkin_sans.otf' -pointsize 60 label:"the last metroid\n. .is in captivity\nthe galaxy\n. .is at peace\n\n\nMawkin\n. .Sans" \
+            demo.png
+fi
 
+echo "Generating mawkin_sans.woff2"
 # Convert OTF to WOFF2 for webfont
-python3 <<PY
+"$PYTHON" <<PY
 from fontTools.ttLib import TTFont
 f = TTFont('mawkin_sans.otf')
 f.flavor='woff2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fontmake
+-e git+https://github.com/silnrsi/pysilfont#egg=pysilfont
+fonttools[ufo,lxml,woff,unicode]


### PR DESCRIPTION
This PR adds support for github actions (to validate font build upon commit to `main` branch).  It also brings wider OS support (for example, a fresh install of ImageMagick on Windows uses the new `magick` command instead of `convert`) and early failure detection (e.g., if there's no Python installation).

Incidentally, my normal build is on OS-X, but this PR was the result of trying to run the build on Windows (in Git bash) and on my Raspberry Pi.  Between those and the github action running on Ubuntu, the build is now fully platform-agnostic.