### PR TITLE
[Docs] Added usage info for non-devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ An example of text can be seen here:
 
 ![The last metroid is in captivity. The galaxy is at peace.](demo.png)
 
+## Usage
+
+Download the [latest version](https://github.com/raffitz/mawkin-sans/releases/latest) of the font.  For desktop use, you'll want to download the `mawkin_sans.otf` file and install it as a system font.  For use on a website, you'll want `mawkin_sans.woff2`, and the following CSS:
+
+```css
+@font-face {
+  font-family: 'mawkin_sansregular';
+  src: url('./mawkin_sans.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+```
+
 ## Building
 
 ### Prerequisites


### PR DESCRIPTION
Got a [user on Reddit](https://www.reddit.com/r/ChozoLanguage/comments/r7xk3p/is_there_a_chozo_font_that_can_be_used_in/) thinking this font was for use with Python and ImageMagick.  I figured it wouldn't be a bad idea to document exactly where the juicy bit was and what to do with it.